### PR TITLE
Pin numpy version on the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM qgis/qgis:release-3_36
 
 # Install required packages
-RUN pip3 install pyeodh pytest pytest-cov pytest-qgis
+# Constrain numpy for compatibility with scipy in QGIS base image
+RUN echo "numpy<1.25.0" > /tmp/constraints.txt && \
+    pip3 install pyeodh pytest pytest-cov pytest-qgis -c /tmp/constraints.txt
 
 # Set the entrypoint script
 COPY .docker/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
The QGIS Docker image (qgis/qgis:release-3_36) has an older scipy compiled for numpy <1.25.0, but when we `pip3 install pyeodh pytest`... it pulls in numpy 2.2.6 as a dependency, causing the binary incompatibility. The fix is to pin numpy to a compatible version in the Dockerfile.