### PR TITLE
Improve layer loading performance

### DIFF
--- a/eodh_qgis/definitions/constants.py
+++ b/eodh_qgis/definitions/constants.py
@@ -34,13 +34,6 @@ NETCDF_MIME_TYPES = [
     "application/netcdf",
 ]
 
-# COG/GeoTIFF MIME types (for vsicurl streaming)
-COG_MIME_TYPES = [
-    "image/tiff; application=geotiff; profile=cloud-optimized",
-    "image/tiff; application=geotiff",
-    "image/tiff",
-]
-
 # Asset keys that are typically data assets
 DATA_ASSET_KEYS = ["quicklook", "data", "visual", "image"]
 

--- a/eodh_qgis/gdal_config.py
+++ b/eodh_qgis/gdal_config.py
@@ -1,0 +1,76 @@
+"""GDAL virtual file system configuration for optimal remote raster streaming.
+
+Sets GDAL configuration options that improve /vsicurl/ performance for
+remote raster loading. Without these options, GDAL's default behavior
+causes excessive HTTP requests (sidecar file probing) and high latency.
+
+Options are applied when the plugin loads and restored when it unloads,
+to avoid affecting other QGIS plugins.
+"""
+
+from __future__ import annotations
+
+from osgeo import gdal
+from qgis.core import Qgis, QgsMessageLog
+
+from eodh_qgis.definitions.constants import PLUGIN_NAME
+
+# GDAL vsicurl performance options for remote raster streaming.
+GDAL_VSICURL_OPTIONS: dict[str, str] = {
+    # Prevent directory listing for sidecar files (.aux.xml, .ovr, .prj).
+    # Single biggest performance win — eliminates 3-5 extra HTTP requests per open.
+    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
+    # Enable RAM caching of fetched byte ranges.
+    "VSI_CACHE": "TRUE",
+    # Cache size: 50 MB (default ~25 MB).
+    "VSI_CACHE_SIZE": "52428800",
+    # Only fetch files with these extensions via curl (blocks sidecar probing).
+    "CPL_VSIL_CURL_ALLOWED_EXTENSIONS": ".tif,.tiff,.png,.jpg,.jpeg",
+    # Combine multiple byte-range requests into one HTTP request.
+    "GDAL_HTTP_MULTIRANGE": "YES",
+    # Merge adjacent byte ranges.
+    "GDAL_HTTP_MERGE_CONSECUTIVE_RANGES": "YES",
+    # Retry on transient HTTP failures.
+    "GDAL_HTTP_MAX_RETRY": "3",
+    "GDAL_HTTP_RETRY_DELAY": "1",
+}
+
+# Stores previous values for restore on unload.
+_previous_values: dict[str, str | None] = {}
+
+
+def configure_gdal_vsicurl() -> None:
+    """Set GDAL config options for optimal vsicurl performance.
+
+    Saves current values before overwriting so they can be restored
+    with restore_gdal_vsicurl(). Call once during plugin initGui().
+    """
+    global _previous_values
+    _previous_values = {}
+
+    for key, value in GDAL_VSICURL_OPTIONS.items():
+        _previous_values[key] = gdal.GetConfigOption(key)
+        gdal.SetConfigOption(key, value)
+
+    QgsMessageLog.logMessage(
+        f"GDAL vsicurl configuration applied ({len(GDAL_VSICURL_OPTIONS)} options)",
+        PLUGIN_NAME,
+        level=Qgis.Info,
+    )
+
+
+def restore_gdal_vsicurl() -> None:
+    """Restore GDAL config options to their previous values.
+
+    Call during plugin unload() to be a good citizen.
+    """
+    for key, previous_value in _previous_values.items():
+        gdal.SetConfigOption(key, previous_value)
+
+    _previous_values.clear()
+
+    QgsMessageLog.logMessage(
+        "GDAL vsicurl configuration restored",
+        PLUGIN_NAME,
+        level=Qgis.Info,
+    )

--- a/eodh_qgis/layer_loader.py
+++ b/eodh_qgis/layer_loader.py
@@ -129,3 +129,18 @@ class KerchunkFetchTask(QgsTask):
                 level=Qgis.Warning,
             )
             return False
+
+    def finished(self, result: bool):
+        """Called on main thread when task completes."""
+        if result and self.variables:
+            QgsMessageLog.logMessage(
+                f"[Task] Kerchunk fetch found {len(self.variables)} variable(s)",
+                PLUGIN_NAME,
+                level=Qgis.Info,
+            )
+        elif self.error:
+            QgsMessageLog.logMessage(
+                f"[Task] Kerchunk fetch failed: {self.error}",
+                PLUGIN_NAME,
+                level=Qgis.Warning,
+            )

--- a/eodh_qgis/layer_loader.py
+++ b/eodh_qgis/layer_loader.py
@@ -1,13 +1,12 @@
-"""Background layer loading task for QGIS.
-
-Simple wrapper around create_layers_for_asset() that runs in background thread.
-"""
+"""Background tasks for QGIS layer loading and kerchunk fetching."""
 
 from __future__ import annotations
 
 from qgis.core import Qgis, QgsMessageLog, QgsRasterLayer, QgsTask
 
+from eodh_qgis.asset_utils import find_kerchunk_reference
 from eodh_qgis.definitions.constants import PLUGIN_NAME
+from eodh_qgis.kerchunk_utils import NetCDFVariableInfo, extract_variables_from_kerchunk
 from eodh_qgis.layer_utils import create_layers_for_asset
 
 
@@ -93,3 +92,40 @@ class LayerLoaderTask(QgsTask):
                 PLUGIN_NAME,
                 level=Qgis.Warning,
             )
+
+
+class KerchunkFetchTask(QgsTask):
+    """Background task to fetch kerchunk reference and extract variables.
+
+    Moves the potentially slow HTTP fetch of kerchunk JSON files off the
+    main thread. On completion, access task.variables for the extracted
+    variable info list (empty if no kerchunk found).
+    """
+
+    def __init__(self, item):
+        super().__init__(f"Fetching kerchunk for {item.id}")
+        self.item = item
+        self.variables: list[NetCDFVariableInfo] = []
+        self.error: str | None = None
+
+    def run(self) -> bool:
+        """Fetch kerchunk reference in background thread."""
+        try:
+            QgsMessageLog.logMessage(
+                f"[Task] Fetching kerchunk for {self.item.id}",
+                PLUGIN_NAME,
+                level=Qgis.Info,
+            )
+            result = find_kerchunk_reference(self.item)
+            if result:
+                _href, kerchunk_data = result
+                self.variables = extract_variables_from_kerchunk(kerchunk_data)
+            return True
+        except Exception as e:
+            self.error = str(e)
+            QgsMessageLog.logMessage(
+                f"[Task] Kerchunk fetch error: {e}",
+                PLUGIN_NAME,
+                level=Qgis.Warning,
+            )
+            return False

--- a/eodh_qgis/main.py
+++ b/eodh_qgis/main.py
@@ -135,6 +135,9 @@ class EodhQgis:
 
     def initGui(self):
         """Create the menu entries and toolbar icons inside the QGIS GUI."""
+        from eodh_qgis.gdal_config import configure_gdal_vsicurl
+
+        configure_gdal_vsicurl()
 
         icon_path = ":/plugins/eodh_qgis/icon.png"
         self.add_action(
@@ -152,6 +155,10 @@ class EodhQgis:
         for action in self.actions:
             self.iface.removePluginWebMenu(self.menu, action)
             self.iface.removeToolBarIcon(action)
+
+        from eodh_qgis.gdal_config import restore_gdal_vsicurl
+
+        restore_gdal_vsicurl()
 
     def run(self):
         """Run method that performs all the real work"""

--- a/eodh_qgis/test/test_gdal_config.py
+++ b/eodh_qgis/test/test_gdal_config.py
@@ -1,0 +1,144 @@
+"""Tests for GDAL vsicurl configuration."""
+
+from __future__ import annotations
+
+import json
+import time
+import unittest
+import urllib.request
+
+from osgeo import gdal
+
+from eodh_qgis.gdal_config import (
+    GDAL_VSICURL_OPTIONS,
+    configure_gdal_vsicurl,
+    restore_gdal_vsicurl,
+)
+
+
+class TestConfigureGdalVsicurl(unittest.TestCase):
+    """Tests for configure/restore GDAL vsicurl options."""
+
+    def tearDown(self):
+        restore_gdal_vsicurl()
+
+    def test_configure_sets_all_options(self):
+        configure_gdal_vsicurl()
+        for key, expected in GDAL_VSICURL_OPTIONS.items():
+            self.assertEqual(gdal.GetConfigOption(key), expected, f"{key} not set")
+
+    def test_restore_resets_options(self):
+        originals = {k: gdal.GetConfigOption(k) for k in GDAL_VSICURL_OPTIONS}
+
+        configure_gdal_vsicurl()
+        restore_gdal_vsicurl()
+
+        for key, original in originals.items():
+            self.assertEqual(gdal.GetConfigOption(key), original, f"{key} not restored")
+
+    def test_preserves_existing_values(self):
+        gdal.SetConfigOption("GDAL_HTTP_MAX_RETRY", "99")
+        try:
+            configure_gdal_vsicurl()
+            self.assertEqual(gdal.GetConfigOption("GDAL_HTTP_MAX_RETRY"), "3")
+
+            restore_gdal_vsicurl()
+            self.assertEqual(gdal.GetConfigOption("GDAL_HTTP_MAX_RETRY"), "99")
+        finally:
+            gdal.SetConfigOption("GDAL_HTTP_MAX_RETRY", None)
+
+    def test_options_has_expected_keys(self):
+        expected = {
+            "GDAL_DISABLE_READDIR_ON_OPEN",
+            "VSI_CACHE",
+            "VSI_CACHE_SIZE",
+            "CPL_VSIL_CURL_ALLOWED_EXTENSIONS",
+            "GDAL_HTTP_MULTIRANGE",
+            "GDAL_HTTP_MERGE_CONSECUTIVE_RANGES",
+            "GDAL_HTTP_MAX_RETRY",
+            "GDAL_HTTP_RETRY_DELAY",
+        }
+        self.assertEqual(set(GDAL_VSICURL_OPTIONS.keys()), expected)
+
+
+def _get_cog_url_from_stac() -> str | None:
+    """Query EODH STAC API for a real Sentinel-2 COG URL."""
+    stac_url = "https://eodatahub.org.uk/api/catalogue/stac/search?collections=sentinel2_ard&limit=1"
+    try:
+        with urllib.request.urlopen(stac_url, timeout=15) as resp:
+            data = json.loads(resp.read())
+        for feat in data.get("features", []):
+            for asset in feat.get("assets", {}).values():
+                if "tiff" in (asset.get("type") or ""):
+                    return asset["href"]
+    except Exception:
+        pass
+    return None
+
+
+class TestVsicurlBenchmark(unittest.TestCase):
+    """Performance benchmark: vsicurl with vs without GDAL config.
+
+    Verifies that the configured options do not degrade performance
+    compared to GDAL defaults.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        gdal.UseExceptions()
+        cls.cog_url = _get_cog_url_from_stac()
+        if not cls.cog_url:
+            raise unittest.SkipTest("Could not fetch COG URL from STAC API")
+
+    def _clear_config(self):
+        for key in GDAL_VSICURL_OPTIONS:
+            gdal.SetConfigOption(key, None)
+
+    def _time_open(self, url: str) -> float:
+        gdal.VSICurlClearCache()
+        start = time.time()
+        ds = gdal.Open(f"/vsicurl/{url}")
+        elapsed = time.time() - start
+        self.assertIsNotNone(ds, f"Failed to open {url}")
+        ds = None
+        return elapsed
+
+    @staticmethod
+    def _median(values: list[float]) -> float:
+        s = sorted(values)
+        return s[len(s) // 2]
+
+    def test_benchmark_configured_not_slower(self):
+        """Config options must not make layer loading slower."""
+        runs = 5
+        url = self.cog_url
+
+        # Baseline: no config
+        self._clear_config()
+        baseline_times = [self._time_open(url) for _ in range(runs)]
+
+        # Configured
+        configure_gdal_vsicurl()
+        try:
+            configured_times = [self._time_open(url) for _ in range(runs)]
+        finally:
+            restore_gdal_vsicurl()
+            self._clear_config()
+
+        # Use median to resist network outliers
+        median_baseline = self._median(baseline_times)
+        median_configured = self._median(configured_times)
+
+        # Allow 15% tolerance for network jitter
+        self.assertLessEqual(
+            median_configured,
+            median_baseline * 1.15,
+            f"Configured ({median_configured:.3f}s) is more than 15% slower "
+            f"than baseline ({median_baseline:.3f}s). "
+            f"Baseline runs: {baseline_times}, "
+            f"Configured runs: {configured_times}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes slow layer loading by addressing three root causes:                                                                                                                                                                   
                                                                                                                                                                                                                              
  - GDAL vsicurl configuration: Sets 8 performance options (disable sidecar file probing, enable byte-range caching, HTTP retries) that eliminate 3-5 unnecessary HTTP requests per layer open                                
  - Move blocking HTTP calls off the UI thread: Metadata XML fetch (10s timeout) is now lazy — only called when the layer, asset, and item all lack CRS info. Kerchunk fetch (30s timeout) moved to a background              
  KerchunkFetchTask                                                                                                                                                                                                           