### PR TITLE
Fix auth settings update duplicating tabs (#219)

### DIFF
--- a/eodh_qgis/gui/overview_widget.py
+++ b/eodh_qgis/gui/overview_widget.py
@@ -8,6 +8,7 @@ from qgis.core import Qgis, QgsMessageLog
 from qgis.PyQt import QtCore, QtGui, QtWidgets, uic
 
 from eodh_qgis.gui.collection_details_dialog import CollectionDetailsDialog
+from eodh_qgis.settings import Settings
 
 # Load the UI file
 FORM_CLASS, _ = uic.loadUiType(os.path.join(os.path.dirname(__file__), "../ui/overview.ui"))
@@ -20,12 +21,11 @@ class OverviewWidget(QtWidgets.QWidget, FORM_CLASS):
     # passes (collection, collection_name)
     collection_changed = QtCore.pyqtSignal(object, str)
 
-    def __init__(self, creds: dict[str, str], parent=None):
+    def __init__(self, parent=None):
         """Constructor."""
         super().__init__(parent)
         self.setupUi(self)
 
-        self.creds = creds
         self.catalog_service: CatalogService | None = None
         self.catalogs: dict[int, Catalog] = {}  # Store catalog objects by index
         self.collections: dict[str, Collection] = {}  # Store collections by ID
@@ -84,8 +84,11 @@ class OverviewWidget(QtWidgets.QWidget, FORM_CLASS):
     def _populate_catalogue_dropdown(self):
         """Populate the dropdown with available catalogues."""
         try:
+            creds = Settings().get_creds()
+            if not creds:
+                return
             self.catalog_service = pyeodh.Client(
-                username=self.creds["username"], token=self.creds["token"]
+                username=creds["username"], token=creds["token"]
             ).get_catalog_service()
 
             catalogs = self.catalog_service.get_catalogs()

--- a/eodh_qgis/gui/process_widget.py
+++ b/eodh_qgis/gui/process_widget.py
@@ -23,12 +23,11 @@ class ProcessWidget(QtWidgets.QWidget, FORM_CLASS):
     Based on v1 main_dialog.py patterns.
     """
 
-    def __init__(self, creds: dict[str, str], parent=None):
+    def __init__(self, parent=None):
         """Constructor."""
         super().__init__(parent)
         self.setupUi(self)
 
-        self.creds = creds
         self.ades_svc = None
         self.selected_button: QtWidgets.QPushButton | None = None
 
@@ -60,9 +59,13 @@ class ProcessWidget(QtWidgets.QWidget, FORM_CLASS):
 
     def get_ades(self):
         """Initialize the ADES service."""
-        username = self.creds["username"]
-        token = self.creds["token"]
-        env = Settings().data["env"]
+        settings = Settings()
+        creds = settings.get_creds()
+        if not creds:
+            return
+        username = creds["username"]
+        token = creds["token"]
+        env = settings.data["env"]
 
         url = "https://eodatahub.org.uk"
         if env == "production":

--- a/eodh_qgis/gui/search_widget.py
+++ b/eodh_qgis/gui/search_widget.py
@@ -34,12 +34,11 @@ FORM_CLASS, _ = uic.loadUiType(os.path.join(os.path.dirname(__file__), "../ui/se
 
 
 class SearchWidget(QtWidgets.QWidget, FORM_CLASS):
-    def __init__(self, creds: dict[str, str], iface=None, parent=None):
+    def __init__(self, iface=None, parent=None):
         """Constructor."""
         super().__init__(parent)
         self.setupUi(self)
 
-        self.creds = creds
         self.iface = iface
         self.catalog = None
         self.collection = None

--- a/eodh_qgis/settings.py
+++ b/eodh_qgis/settings.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from qgis.core import QgsApplication, QgsAuthMethodConfig
 from qgis.PyQt import QtCore
 
 
@@ -9,6 +12,26 @@ class Settings:
             "env": "production",
         }
         self.load_all()
+
+    def get_creds(self) -> dict[str, str] | None:
+        """Retrieve stored authentication credentials from the QGIS auth manager.
+
+        Returns:
+            A dictionary with 'token' and 'username' if available, else None.
+        """
+        auth_config_id = self.data["auth_config"]
+        if not auth_config_id:
+            return None
+        auth_mgr = QgsApplication.authManager()
+        cfg = QgsAuthMethodConfig()
+        auth_mgr.loadAuthenticationConfig(auth_config_id, cfg, True)
+        creds = {
+            "token": cfg.configMap().get("token"),
+            "username": cfg.configMap().get("username"),
+        }
+        if not creds.get("token") or not creds.get("username"):
+            return None
+        return creds
 
     def load(self, key):
         qs = QtCore.QSettings()

--- a/eodh_qgis/test/test_eodh_qgis_dialog.py
+++ b/eodh_qgis/test/test_eodh_qgis_dialog.py
@@ -47,3 +47,18 @@ class EodhQgisDialogTest(unittest.TestCase):
         # Should switch to settings tab
         settings_index = self.dialog.tab_widget.indexOf(self.dialog.settings_widget)
         self.assertEqual(self.dialog.tab_widget.currentIndex(), settings_index)
+
+    @patch("eodh_qgis.gui.main_dialog.MainDialog.get_creds")
+    def test_setup_ui_after_token_no_tab_duplication(self, mock_get_creds):
+        """Test that calling setup_ui_after_token multiple times does not duplicate tabs."""
+        mock_get_creds.return_value = {"username": "user", "token": "tok"}
+
+        # Call setup twice (simulates credential update)
+        self.dialog.setup_ui_after_token()
+        self.dialog.setup_ui_after_token()
+
+        tab_names = [self.dialog.tab_widget.tabText(i) for i in range(self.dialog.tab_widget.count())]
+        # Should have exactly one of each, not duplicates
+        self.assertEqual(tab_names.count("Overview"), 1)
+        self.assertEqual(tab_names.count("Search"), 1)
+        self.assertEqual(tab_names.count("Process"), 1)

--- a/eodh_qgis/test/test_search_widget.py
+++ b/eodh_qgis/test/test_search_widget.py
@@ -15,11 +15,10 @@ class TestSearchWidget(unittest.TestCase):
         assert cls.QGIS_APP is not None
 
     def setUp(self):
-        self.creds = {"username": "test_user", "token": "test_token"}
         self.mock_iface = MagicMock()
         self.mock_canvas = MagicMock()
         self.mock_iface.mapCanvas.return_value = self.mock_canvas
-        self.widget = SearchWidget(creds=self.creds, iface=self.mock_iface, parent=None)
+        self.widget = SearchWidget(iface=self.mock_iface, parent=None)
 
     def tearDown(self):
         self.widget = None
@@ -33,7 +32,7 @@ class TestSearchWidget(unittest.TestCase):
         mock_catalog.search.return_value = []  # Empty results
 
         # Use widget without iface for this test
-        widget = SearchWidget(creds=self.creds, iface=None, parent=None)
+        widget = SearchWidget(iface=None, parent=None)
         widget.catalog = mock_catalog
         widget.collection = mock_collection
 
@@ -241,7 +240,7 @@ class TestSearchWidget(unittest.TestCase):
         mock_catalog.search.return_value = []  # Empty results
 
         # Use widget without iface for this test
-        widget = SearchWidget(creds=self.creds, iface=None, parent=None)
+        widget = SearchWidget(iface=None, parent=None)
         widget.catalog = mock_catalog
         widget.collection = mock_collection
 
@@ -273,7 +272,7 @@ class TestSearchWidget(unittest.TestCase):
         mock_catalog.search.return_value = []  # Empty results
 
         # Use widget without iface for this test
-        widget = SearchWidget(creds=self.creds, iface=None, parent=None)
+        widget = SearchWidget(iface=None, parent=None)
         widget.catalog = mock_catalog
         widget.collection = None  # No collection selected
 
@@ -306,7 +305,7 @@ class TestSearchWidget(unittest.TestCase):
         mock_collection.id = "sentinel-2"
         mock_catalog.search.return_value = []
 
-        widget = SearchWidget(creds=self.creds, iface=None, parent=None)
+        widget = SearchWidget(iface=None, parent=None)
         widget.catalog = mock_catalog
         widget.collection = mock_collection
 
@@ -336,7 +335,7 @@ class TestSearchWidget(unittest.TestCase):
         mock_paginated_list.__getitem__ = MagicMock(return_value=[MagicMock() for _ in range(50)])
         mock_catalog.search.return_value = mock_paginated_list
 
-        widget = SearchWidget(creds=self.creds, iface=None, parent=None)
+        widget = SearchWidget(iface=None, parent=None)
         widget.catalog = mock_catalog
 
         # Set bbox values
@@ -377,7 +376,7 @@ class TestSearchWidget(unittest.TestCase):
         mock_paginated_list.__getitem__ = mock_getitem
         mock_catalog.search.return_value = mock_paginated_list
 
-        widget = SearchWidget(creds=self.creds, iface=None, parent=None)
+        widget = SearchWidget(iface=None, parent=None)
         widget.catalog = mock_catalog
 
         # Set bbox values
@@ -416,7 +415,7 @@ class TestSearchWidget(unittest.TestCase):
         mock_paginated_list.__getitem__ = mock_getitem
         mock_catalog.search.return_value = mock_paginated_list
 
-        widget = SearchWidget(creds=self.creds, iface=None, parent=None)
+        widget = SearchWidget(iface=None, parent=None)
         widget.catalog = mock_catalog
 
         # Set bbox values
@@ -453,7 +452,7 @@ class TestSearchWidget(unittest.TestCase):
         mock_paginated_list.__getitem__ = mock_getitem
         mock_catalog.search.return_value = mock_paginated_list
 
-        widget = SearchWidget(creds=self.creds, iface=None, parent=None)
+        widget = SearchWidget(iface=None, parent=None)
         widget.catalog = mock_catalog
 
         # Set bbox values


### PR DESCRIPTION
Centralize credentials in Settings.get_creds() so widgets read from the QGIS auth manager on demand instead of receiving creds as a constructor parameter. Tabs are now created once in MainDialog.__init__ rather than being recreated on every credential change, eliminating the duplication.